### PR TITLE
Adopt extended SnappThemingExternalImageProcessorProtocol with URL support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/SVGKit/SVGKit.git", from: "3.0.0"),
-        .package(url: "https://github.com/Snapp-Mobile/SnappTheming", from: "0.1.2"),
+        .package(url: "https://github.com/Snapp-Mobile/SnappTheming", branch: "next"),
         .package(url: "https://github.com/Snapp-Mobile/SwiftFormatLintPlugin.git", exact: "1.0.4"),
     ],
     targets: [

--- a/Sources/SnappThemingSVGSupport/SnappThemingSVGSupportImageConverter.swift
+++ b/Sources/SnappThemingSVGSupport/SnappThemingSVGSupportImageConverter.swift
@@ -10,49 +10,59 @@ import OSLog
 import SVGKit
 import SnappTheming
 
-/// A utility class for converts SVG data into a `UIImage`.
-final class SnappThemingSVGSupportImageConverter {
-    /// The rendered `UIImage` representation of the SVG data.
-    private(set) var image: SnappThemingImage
-
+/// A utility class for converts SVG data into a `SnappThemingImage`.
+final class SnappThemingSVGSupportImageConverter: Sendable {
     /// Initializes the `SnappThemingSVGSupportImageConverter` with the provided SVG data.
     ///
     /// - Parameters:
-    ///   - data: The SVG data to be rendered into a `SnappThemingImage`.
+    ///   - object: The object of `SnappThemingImageObject` type to contain SVG image data and file url if available.
     ///   - svgImageType: The type used for SVG rendering, defaulting to `SVGKImage.self`.
     ///   - fallbackImageName: The system image name used as a fallback if the SVG data is invalid or cannot be rendered.
     ///
     /// - Note: If the SVG data is invalid or rendering fails, a system image with the name specified in `fallbackImageName`
     ///   (default: `"exclamationmark.triangle"`) will be used instead.
-    init(
-        data: Data,
-        svgImageType: SVGKImage.Type = SVGKImage.self,
-        fallbackImageName: String = "exclamationmark.triangle"
-    ) {
-        var svgImage: SVGKImage? = svgImageType.init(data: data)
+    func convert(
+        _ object: SnappThemingImageObject,
+        ofType svgImageType: SVGKImage.Type = SVGKImage.self,
+        withFallback fallbackImageName: String = "exclamationmark.triangle"
+    ) -> SnappThemingImage {
+        let svgImage: SVGKImage?
 
-        // Retry logic for simulator or potential parsing issues
-        // error: `*** Assertion failure in +[SVGLength pixelsPerInchForCurrentDevice], SVGLength.m:238`
-        if svgImage == nil {
-            os_log(.info, "Initial SVG parsing failed. Retrying...")
-            svgImage = svgImageType.init(data: data)
+        if let url = object.url {
+            svgImage = prepareSVGImage(using: url, svgImageType: svgImageType)
+        } else {
+            svgImage = prepareSVGImage(using: object.data, svgImageType: svgImageType)
         }
 
         if let validSVGImage = svgImage {
             if let renderedImage = validSVGImage.themeImage {
-                self.image = renderedImage
+                return renderedImage
             } else {
-                self.image = Self.defaultFallbackImage(fallbackImageName)
                 os_log(.error, "Failed to render SVG to UIImage. Using fallback image.")
+                return Self.defaultFallbackImage(fallbackImageName)
             }
         } else {
-            self.image = Self.defaultFallbackImage(fallbackImageName)
             os_log(.error, "Failed to parse SVG data after retry. Using fallback image.")
+            return Self.defaultFallbackImage(fallbackImageName)
         }
     }
 
     /// The default fallback image to use when SVG rendering fails.
     private static func defaultFallbackImage(_ name: String) -> SnappThemingImage {
         .system(name) ?? SnappThemingImage()
+    }
+
+    private func prepareSVGImage(using url: URL, svgImageType: SVGKImage.Type) -> SVGKImage? {
+        // Retry logic for simulator or potential parsing issues
+        // error: `*** Assertion failure in +[SVGLength pixelsPerInchForCurrentDevice], SVGLength.m:238`
+        // First attempt may fail with PPI assertion, but retry succeeds due to UIScreen initialization
+        svgImageType.init(contentsOfFile: url.path()) ?? svgImageType.init(contentsOfFile: url.path())
+    }
+
+    private func prepareSVGImage(using data: Data, svgImageType: SVGKImage.Type) -> SVGKImage? {
+        // Retry logic for simulator or potential parsing issues
+        // error: `*** Assertion failure in +[SVGLength pixelsPerInchForCurrentDevice], SVGLength.m:238`
+        // First attempt may fail with PPI assertion, but retry succeeds due to UIScreen initialization
+        svgImageType.init(data: data) ?? svgImageType.init(data: data)
     }
 }

--- a/Sources/SnappThemingSVGSupport/SnappThemingSVGSupportSVGProcessor.swift
+++ b/Sources/SnappThemingSVGSupport/SnappThemingSVGSupportSVGProcessor.swift
@@ -20,6 +20,8 @@ extension SnappThemingExternalImageProcessorProtocol where Self == SnappThemingS
 
 /// A processor for handling SVG image data, conforming to `SnappThemingExternalImageProcessorProtocol`.
 public struct SnappThemingSVGSupportSVGProcessor: SnappThemingExternalImageProcessorProtocol {
+    private let converter: SnappThemingSVGSupportImageConverter
+
     /// Processes the provided image data and type and converts it into a `SnappThemingImage` if the type is `.svg`.
     ///
     /// - Parameter data: Image `Data`.
@@ -31,17 +33,19 @@ public struct SnappThemingSVGSupportSVGProcessor: SnappThemingExternalImageProce
     ///
     /// - Note: This method specifically handles `.svg` type. If the type does not match, the method returns `nil`.
     /// - Warning: Ensure that the `data` is valid SVG data to avoid potential rendering issues.
-    public func process(_ data: Data, of type: UTType) -> SnappThemingImage? {
+    public func process(_ object: SnappThemingImageObject, of type: UTType) -> SnappThemingImage? {
         guard type == .svg else {
             os_log(.error, "Invalid type provided: %{public}@. Only .svg type is supported.", "\(type)")
             return nil
         }
 
-        return SnappThemingSVGSupportImageConverter(data: data).image
+        return converter.convert(object)
     }
 
     /// Initializes the `SnappThemingSVGSupportSVGProcessor`.
     ///
     /// This default initializer is used to create instances of the processor for processing SVG data.
-    public init() {}
+    public init() {
+        converter = SnappThemingSVGSupportImageConverter()
+    }
 }

--- a/Tests/SnappThemingSVGSupportTests/ImageConverterTests.swift
+++ b/Tests/SnappThemingSVGSupportTests/ImageConverterTests.swift
@@ -13,48 +13,54 @@ import Testing
 
 @Suite
 struct ImageConverterTests {
+    private let converter = SnappThemingSVGSupportImageConverter()
+
     @Test
     func testConverterSuccessfulConversionExpectedImage() throws {
         let expectedImageData = try #require(svgIconString.data(using: .utf8))
-        let converter = SnappThemingSVGSupportImageConverter(data: expectedImageData)
+        let object = SnappThemingImageObject(data: expectedImageData)
+        let image = converter.convert(object)
 
-        #expect(converter.image.size == CGSize(width: 24, height: 24))
+        #expect(image.size == CGSize(width: 24, height: 24))
     }
 
     @Test
     func testConverterSVGImageFailedFallbackImage() throws {
         let expectedImageData = try #require(svgIconString.data(using: .utf8))
-        let converter = SnappThemingSVGSupportImageConverter(data: expectedImageData, svgImageType: MockSVGKImage.self)
+        let object = SnappThemingImageObject(data: expectedImageData)
+        let image = converter.convert(object, ofType: MockSVGKImage.self)
         let fallbackImage: SnappThemingImage = try #require(.system("exclamationmark.triangle"))
 
-        #expect(converter.image.size != CGSize(width: 24, height: 24))
+        #expect(image.size != CGSize(width: 24, height: 24))
         #if canImport(UIKit)
-            #expect(converter.image == fallbackImage)
+            #expect(image == fallbackImage)
         #elseif canImport(AppKit)
-            #expect(converter.image.tiffRepresentation == fallbackImage.tiffRepresentation)
+            #expect(image.tiffRepresentation == fallbackImage.tiffRepresentation)
         #endif
     }
 
     @Test
     func testConverterEmptyDataFallbackImage() async throws {
-        let converter = SnappThemingSVGSupportImageConverter(data: Data())
+        let object = SnappThemingImageObject(data: Data())
+        let image = converter.convert(object)
         let fallbackImage: SnappThemingImage = try #require(.system("exclamationmark.triangle"))
         #if canImport(UIKit)
-            #expect(converter.image == fallbackImage)
+            #expect(image == fallbackImage)
         #elseif canImport(AppKit)
-            #expect(converter.image.tiffRepresentation == fallbackImage.tiffRepresentation)
+            #expect(image.tiffRepresentation == fallbackImage.tiffRepresentation)
         #endif
     }
 
     @Test
     func testConverterEmptyDataAndBrokenFallbackImage() async throws {
-        let converter = SnappThemingSVGSupportImageConverter(data: Data(), fallbackImageName: "")
+        let object = SnappThemingImageObject(data: Data())
+        let image = converter.convert(object, withFallback: "")
         let fallbackImage: SnappThemingImage = try #require(.system("exclamationmark.triangle"))
         #if canImport(UIKit)
-            #expect(converter.image == SnappThemingImage())
+            #expect(image == SnappThemingImage())
         #elseif canImport(AppKit)
-            #expect(converter.image.tiffRepresentation != fallbackImage.tiffRepresentation)
-            #expect(converter.image.tiffRepresentation == nil)
+            #expect(image.tiffRepresentation != fallbackImage.tiffRepresentation)
+            #expect(image.tiffRepresentation == nil)
         #endif
     }
 }

--- a/Tests/SnappThemingSVGSupportTests/SVGProcessorTests.swift
+++ b/Tests/SnappThemingSVGSupportTests/SVGProcessorTests.swift
@@ -17,19 +17,22 @@ struct SVGProcessorTests {
 
     @Test
     func testSVGProcessorFail() {
-        #expect(sut.process(Data(), of: .png) == nil)
-        #expect(sut.process(Data(), of: .jpeg) == nil)
-        #expect(sut.process(Data(), of: .pdf) == nil)
-        #expect(sut.process(Data(), of: .gif) == nil)
+        let object = SnappThemingImageObject(data: Data())
+        #expect(sut.process(object, of: .png) == nil)
+        #expect(sut.process(object, of: .jpeg) == nil)
+        #expect(sut.process(object, of: .pdf) == nil)
+        #expect(sut.process(object, of: .gif) == nil)
     }
 
     @Test
     func testSVGProcessorFallback() throws {
         let emptyStringData = try #require("".data(using: .utf8))
         let fallbackImage: SnappThemingImage = try #require(.system("exclamationmark.triangle"))
+        let emptyStringDataObject = SnappThemingImageObject(data: emptyStringData)
 
-        let emptyStringDataImage = try #require(sut.process(emptyStringData, of: .svg))
-        let emptyDataImage = try #require(sut.process(Data(), of: .svg))
+        let emptyStringDataImage = try #require(sut.process(emptyStringDataObject, of: .svg))
+        let emptyDataObject = SnappThemingImageObject(data: Data())
+        let emptyDataImage = try #require(sut.process(emptyDataObject, of: .svg))
 
         #if canImport(UIKit)
             #expect(emptyStringDataImage == fallbackImage)
@@ -44,7 +47,8 @@ struct SVGProcessorTests {
     @Test
     func testSVGProcessorExpectedImage() throws {
         let svgData = try #require(svgIconString.data(using: .utf8))
-        let processedIcon = try #require(sut.process(svgData, of: .svg))
+        let svgDataObject = SnappThemingImageObject(data: svgData)
+        let processedIcon = try #require(sut.process(svgDataObject, of: .svg))
 
         #expect(processedIcon.size.width == 24)
         #expect(processedIcon.size.height == 24)


### PR DESCRIPTION
## What
Update image processing to accept optional URL alongside image data

## Why
External image processors (especially SVG) need URL context for proper initialization and caching. This fixes SVGKit warnings and rendering issues when switching between themes

## Changes
- Sources/SnappThemingSVGSupport/SnappThemingSVGSupportSVGProcessor.swift
- Sources/SnappThemingSVGSupport/SnappThemingSVGSupportImageConverter.swift