### PR TITLE
Doc link for swift package index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://ios-theming.snappmobile.io/documentation/snappthemingsvgsupport"


### PR DESCRIPTION
## What
Documentation URL for Swift Package Index 

## Why
To have documentation button there

## Changes
add `.spi.yml`